### PR TITLE
[breaking] Allow specifying the kafka partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS outbox (
   create_time         TIMESTAMP WITH TIME ZONE NOT NULL,
   kafka_topic         VARCHAR(249) NOT NULL,
   kafka_key           VARCHAR(100) NOT NULL,  -- pick your own maximum key size
+  kafka_partition     INTEGER DEFAULT -1 NOT NULL,
   kafka_value         VARCHAR(10000),         -- pick your own maximum value size
   kafka_header_keys   TEXT[] NOT NULL,
   kafka_header_values TEXT[] NOT NULL,

--- a/db.go
+++ b/db.go
@@ -23,13 +23,14 @@ type KafkaHeaders []KafkaHeader
 
 // OutboxRecord depicts a single entry in the outbox table. It can be used for both reading and writing operations.
 type OutboxRecord struct {
-	ID           int64
-	CreateTime   time.Time
-	KafkaTopic   string
-	KafkaKey     string
-	KafkaValue   *string
-	KafkaHeaders KafkaHeaders
-	LeaderID     *uuid.UUID
+	ID             int64
+	CreateTime     time.Time
+	KafkaTopic     string
+	KafkaKey       string
+	KafkaPartition int32
+	KafkaValue     *string
+	KafkaHeaders   KafkaHeaders
+	LeaderID       *uuid.UUID
 }
 
 // String is a convenience function that returns a pointer to the given str argument, for use with setting OutboxRecord.Value.
@@ -43,6 +44,7 @@ func (rec OutboxRecord) String() string {
 		", CreateTime=", rec.CreateTime,
 		", KafkaTopic=", rec.KafkaTopic,
 		", KafkaKey=", rec.KafkaKey,
+		", KafkaPartition=", rec.KafkaPartition,
 		", KafkaValue=", rec.KafkaValue,
 		", KafkaHeaders=", rec.KafkaHeaders,
 		", LeaderID=", rec.LeaderID, "]")

--- a/harvest.go
+++ b/harvest.go
@@ -313,8 +313,13 @@ func (h *harvest) spawnSendBattery() {
 			ensureState(lastID == nil || rec.ID >= *lastID, "discontinuity for key %s: ID %s, lastID: %v", rec.KafkaKey, rec.ID, lastID)
 			lastID = &rec.ID
 
+			kafkaPartition := rec.KafkaPartition
+			if kafkaPartition == -1 {
+				kafkaPartition = kafka.PartitionAny
+			}
+
 			m := &kafka.Message{
-				TopicPartition: kafka.TopicPartition{Topic: &rec.KafkaTopic, Partition: kafka.PartitionAny},
+				TopicPartition: kafka.TopicPartition{Topic: &rec.KafkaTopic, Partition: kafkaPartition},
 				Key:            []byte(rec.KafkaKey),
 				Value:          stringPointerToByteArray(rec.KafkaValue),
 				Opaque:         rec,

--- a/postgres.go
+++ b/postgres.go
@@ -28,7 +28,7 @@ WHERE id IN (
   ORDER BY id
   LIMIT $2
 )
-RETURNING id, create_time, kafka_topic, kafka_key, kafka_value, kafka_header_keys, kafka_header_values, leader_id
+RETURNING id, create_time, kafka_topic, kafka_key, kafka_partition, kafka_value, kafka_header_keys, kafka_header_values, leader_id
 `
 
 const purgeQueryTemplate = `
@@ -131,6 +131,7 @@ func (db *database) Mark(leaderID uuid.UUID, limit int) ([]OutboxRecord, error) 
 			&record.CreateTime,
 			&record.KafkaTopic,
 			&record.KafkaKey,
+			&record.KafkaPartition,
 			&record.KafkaValue,
 			pq.Array(&keys),
 			pq.Array(&values),

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -122,12 +122,13 @@ func TestExecuteMarkQuery_scanError(t *testing.T) {
 		"create_time",
 		"kafka_topic",
 		"kafka_key",
+		"kafka_partition",
 		"kafka_value",
 		"kafka_header_keys",
 		"kafka_header_values",
 		"leader_id",
 	})
-	rows.AddRow("non-int", "", "", "", "", pq.Array([]string{"some-key"}), pq.Array([]string{"some-value"}), leaderID)
+	rows.AddRow("non-int", "", "", "", "", "", pq.Array([]string{"some-key"}), pq.Array([]string{"some-value"}), leaderID)
 	mark.ExpectQuery().WithArgs(leaderID, testMarkQueryLimit).WillReturnRows(rows)
 
 	records, err := b.Mark(leaderID, testMarkQueryLimit)
@@ -150,24 +151,26 @@ func TestExecuteMark_success(t *testing.T) {
 	leaderID, _ := uuid.NewRandom()
 	exp := []OutboxRecord{
 		{
-			ID:         77,
-			CreateTime: time.Now(),
-			KafkaTopic: "kafka_topic",
-			KafkaKey:   "kafka_key",
-			KafkaValue: String("kafka_value"),
+			ID:             77,
+			CreateTime:     time.Now(),
+			KafkaTopic:     "kafka_topic",
+			KafkaKey:       "kafka_key",
+			KafkaPartition: 1,
+			KafkaValue:     String("kafka_value"),
 			KafkaHeaders: KafkaHeaders{
 				KafkaHeader{Key: "some-key", Value: "some-value"},
 			},
 			LeaderID: nil,
 		},
 		{
-			ID:           78,
-			CreateTime:   time.Now(),
-			KafkaTopic:   "kafka_topic",
-			KafkaKey:     "kafka_key",
-			KafkaValue:   String("kafka_value"),
-			KafkaHeaders: KafkaHeaders{},
-			LeaderID:     nil,
+			ID:             78,
+			CreateTime:     time.Now(),
+			KafkaTopic:     "kafka_topic",
+			KafkaKey:       "kafka_key",
+			KafkaPartition: 1,
+			KafkaValue:     String("kafka_value"),
+			KafkaHeaders:   KafkaHeaders{},
+			LeaderID:       nil,
 		},
 	}
 	reverse := func(recs []OutboxRecord) []OutboxRecord {
@@ -183,6 +186,7 @@ func TestExecuteMark_success(t *testing.T) {
 		"create_time",
 		"kafka_topic",
 		"kafka_key",
+		"kafka_partition",
 		"kafka_value",
 		"kafka_header_keys",
 		"kafka_header_values",
@@ -196,6 +200,7 @@ func TestExecuteMark_success(t *testing.T) {
 			expRec.CreateTime,
 			expRec.KafkaTopic,
 			expRec.KafkaKey,
+			expRec.KafkaPartition,
 			expRec.KafkaValue,
 			pq.Array(headerKeys),
 			pq.Array(headerValues),
@@ -227,6 +232,7 @@ func TestExecuteMark_headerLengthMismatch(t *testing.T) {
 		"create_time",
 		"kafka_topic",
 		"kafka_key",
+		"kafka_partition",
 		"kafka_value",
 		"kafka_header_keys",
 		"kafka_header_values",
@@ -237,6 +243,7 @@ func TestExecuteMark_headerLengthMismatch(t *testing.T) {
 		time.Now(),
 		"some-topic",
 		"some-key",
+		-1,
 		"some-value",
 		pq.Array([]string{"k0"}),
 		pq.Array([]string{"v0", "v1"}),


### PR DESCRIPTION
This allows using different partition keys but still send the records to the same partition. E.g. I want all the records from the same account to be in the same partition, but I want to use the user id as the key.

This also helps to make the goharvest more effecient because now we can have more distributed load even though the records still end up in the same partitions.

**BREAKING CHANGE**: `kafka_partition` field must be added to the outbox table before using this code.