### PR TITLE
Expose election group join completion via Harvest.IsGroupJoined()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/obsidiandynamics/goneli => github.com/salemove/goneli v0.0.0-20260612104534-a041696a73ef
+replace github.com/obsidiandynamics/goneli => github.com/salemove/goneli v0.0.0-20260616091238-a16ba052266f

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/salemove/goneli v0.0.0-20260612104534-a041696a73ef h1:HzT6vbQz+rzwjb3/e0W87BQ5Ij5fIVuQLtdUzo/ClB8=
-github.com/salemove/goneli v0.0.0-20260612104534-a041696a73ef/go.mod h1:FQGQ9ajGAzcZDZ1GY5bQX2fQna8YQaVriUiTMRnleig=
+github.com/salemove/goneli v0.0.0-20260616091238-a16ba052266f h1:LKVHIPps/lYPztcqWtWaAVbZ1k4jKaiyHwBEu4SNm9o=
+github.com/salemove/goneli v0.0.0-20260616091238-a16ba052266f/go.mod h1:FQGQ9ajGAzcZDZ1GY5bQX2fQna8YQaVriUiTMRnleig=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
 github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b h1:h+3JX2VoWTFuyQEo87pStk/a99dzIO1mM9KxIyLPGTU=

--- a/harvest.go
+++ b/harvest.go
@@ -51,6 +51,7 @@ type Harvest interface {
 	Await() error
 	State() State
 	IsLeader() bool
+	IsGroupJoined() bool
 	LeaderID() *uuid.UUID
 	InFlightRecords() int
 	InFlightRecordKeys() []string
@@ -184,6 +185,15 @@ func (h *harvest) Start() error {
 // IsLeader returns true if the current Harvest is the leader among competing instances.
 func (h *harvest) IsLeader() bool {
 	return h.LeaderID() != nil
+}
+
+// IsGroupJoined returns true once the harvester has completed the initial join
+// of its leader election group.
+func (h *harvest) IsGroupJoined() bool {
+	if h.State() == Created {
+		return false
+	}
+	return h.neli.IsGroupJoined()
 }
 
 // LeaderID returns the leader UUID of the current instance, if it is a leader at the time of this call.

--- a/harvest_test.go
+++ b/harvest_test.go
@@ -134,8 +134,10 @@ func TestCorrectInitialisation(t *testing.T) {
 	h, err := New(config)
 	require.Nil(t, err)
 	assert.Equal(t, Created, h.State())
+	assert.False(t, h.IsGroupJoined())
 	assertNoError(t, h.Start)
 	assert.Equal(t, Running, h.State())
+	assert.True(t, h.IsGroupJoined())
 
 	assert.Equal(t, config.DataSource, givenDataSource)
 	assert.Equal(t, config.OutboxTable, givenOutboxTable)


### PR DESCRIPTION
Delegates to the new goneli Neli.IsGroupJoined(), which reports whether the NELI election consumer's initial group join has completed (first rebalance callback received). Applications can use this to gate their readiness signal so that an instance is not reported ready while it is still joining the leader election group.