### PR TITLE
Demote send-cell ID discontinuity log from error to warning

### DIFF
--- a/harvest.go
+++ b/harvest.go
@@ -320,7 +320,7 @@ func (h *harvest) spawnSendBattery() {
 		var lastID *int64
 		for rec := range records {
 			if lastID != nil && rec.ID < *lastID {
-				h.logger().E()("Discontinuity for key %s: ID %d, lastID: %d", rec.KafkaKey, rec.ID, *lastID)
+				h.logger().W()("Discontinuity for key %s: ID %d, lastID: %d", rec.KafkaKey, rec.ID, *lastID)
 			}
 			lastID = &rec.ID
 

--- a/harvest_test.go
+++ b/harvest_test.go
@@ -567,9 +567,9 @@ func TestMarkedIDDiscontinuity(t *testing.T) {
 	second := generateRecords(1, 100)
 	db.markedRecords <- second
 
-	// The discontinuity is logged as an error...
+	// The discontinuity is logged as a warning...
 	wait(t).UntilAsserted(m.ContainsEntries().
-		Having(scribe.LogLevel(scribe.Error)).
+		Having(scribe.LogLevel(scribe.Warn)).
 		Having(scribe.MessageEqual("Discontinuity for key key-0: ID 100, lastID: 200")).
 		Passes(scribe.Count(1)))
 


### PR DESCRIPTION
An ID discontinuity across keys within a cell is benign, as established in 9882444 ("Demote send-cell ID discontinuity assertion to an error log", 2026-06-12): outbox IDs come from a sequence assigned at insert time but rows only become visible to the mark query at commit time, so a slow-committing transaction can legitimately surface a lower ID after a higher one has already been marked. Per-key ordering - the guarantee that matters - is enforced separately via the `inFlightKeys` drain.

In practice this turns out to happen frequently under load, and logging it at error level just creates a lot of noise. Demote it to a warning.